### PR TITLE
Add database to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Ignore SQLite database file
+database.sqlite


### PR DESCRIPTION
chore(git): add database.sqlite to .gitignore
 ### What
*********************
It aims to fix a few problems:
- Added the database.sqlite file to .gitignore to prevent it from being tracked by Git. This ensures that local database files are not included in the repository.

### Why
*********************
- **Avoid Version Control Issues:** Tracking the `database.sqlite` file in Git can lead to conflicts between different environments, as each developer or deployment might generate different data.
- **Maintain Clean Repository:** Including the database file can unnecessarily bloat the repository with binary data that doesn’t contribute to the codebase.
- **Protect Sensitive Data:** Local SQLite databases may contain sensitive or environment-specific information that should not be shared or stored in version control.
